### PR TITLE
Add Bearer token authentication middleware for MCP endpoints

### DIFF
--- a/dist/production-server.js
+++ b/dist/production-server.js
@@ -46,6 +46,22 @@ if (isProduction) {
         next();
     });
 }
+// MCP authentication middleware
+app.use('/mcp', (req, res, next) => {
+    const authHeader = req.headers.authorization;
+    const expectedToken = 'Bearer salesforce-mcp-token-2024'; // Use your token
+    if (!authHeader || authHeader !== expectedToken) {
+        return res.status(401).json({
+            jsonrpc: '2.0',
+            id: null,
+            error: {
+                code: -32600,
+                message: 'Invalid or missing authentication token'
+            }
+        });
+    }
+    next();
+});
 // Health check endpoint
 app.get('/health', (req, res) => {
     res.json({

--- a/src/production-server.ts
+++ b/src/production-server.ts
@@ -54,6 +54,25 @@ if (isProduction) {
   });
 }
 
+// MCP authentication middleware
+app.use('/mcp', (req, res, next) => {
+  const authHeader = req.headers.authorization;
+  const expectedToken = 'Bearer salesforce-mcp-token-2024'; // Use your token
+  
+  if (!authHeader || authHeader !== expectedToken) {
+    return res.status(401).json({
+      jsonrpc: '2.0',
+      id: null,
+      error: {
+        code: -32600,
+        message: 'Invalid or missing authentication token'
+      }
+    });
+  }
+  
+  next();
+});
+
 // Health check endpoint
 app.get('/health', (req, res) => {
   res.json({ 


### PR DESCRIPTION
- Add authentication middleware for /mcp routes requiring Bearer token
- Use 'salesforce-mcp-token-2024' as expected token for Vapi integration
- Return proper JSON-RPC error responses for invalid/missing auth
- Secure MCP endpoint access for production deployment

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Authentication requirement added for API access with token validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->